### PR TITLE
fix(release.yml): add deploy key for auto-publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+
 on:
   push:
     branches:
@@ -17,6 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_ACTION_KEY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
Deploy key should let the GitHub Action bypass the main branch protection and let the package auto-publish on push or merge