### PR TITLE
ci(release.yml): add build step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
         run: npm clean-install
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
+      - name: Build package
+        run: npm run build
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISH_PAT }}


### PR DESCRIPTION
The GitHub action for publishing and releasing the package now builds the package before release